### PR TITLE
Add to Context not empty return_to

### DIFF
--- a/redirect_back.go
+++ b/redirect_back.go
@@ -130,7 +130,9 @@ func (redirectBack *RedirectBack) RedirectBack(w http.ResponseWriter, req *http.
 func (redirectBack *RedirectBack) Middleware(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		returnTo := redirectBack.config.SessionManager.Get(req, "return_to")
-		req = req.WithContext(context.WithValue(req.Context(), returnToKey, returnTo))
+		if returnTo != "" {
+			req = req.WithContext(context.WithValue(req.Context(), returnToKey, returnTo))
+		}
 
 		if !redirectBack.Ignore(req) && returnTo != req.URL.String() {
 			redirectBack.config.SessionManager.Add(w, req, "return_to", req.URL.String())


### PR DESCRIPTION
In some cases user redirected to blank page, because `returnTo` is empty string instead of `nil`.